### PR TITLE
Generate javadoc on install. Issue #3 resolve

### DIFF
--- a/fenixedu-project/pom.xml
+++ b/fenixedu-project/pom.xml
@@ -79,7 +79,7 @@
                 <executions>
                     <execution>
                         <id>attach-javadoc</id>
-                        <phase>deploy</phase>
+                        <phase>install</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>


### PR DESCRIPTION
This will force developers to fix javadoc issues during the development process.